### PR TITLE
fix: put the envvars args value in double quotes and execute the az container deploy command through eval

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,8 +2,18 @@
 
 AZVARS="M5=Magna5"
 for var in ${PLUGIN_ENVVARS//,/ }; do
-    AZVARS=${AZVARS},$var=${!var:-missing}
+  AZVARS=${AZVARS},$var="${!var:-missing}"
 done
 
+# Put the env variables in quotes "" to accomodate space in values
+AZVARS=$(echo $AZVARS | sed 's/=\([^,^$]*\)/="\1"/g')
+
+# Print the command being executed
+set -x
+
 az login --service-principal -u ${PLUGIN_AZURE_APPID} -p ${PLUGIN_AZURE_PASSWORD} --tenant ${PLUGIN_AZURE_TENANT} || exit 1
-az container create --resource-group ${PLUGIN_RESOURCE_GROUP} --name ${PLUGIN_CONTAINER_NAME} --image ${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION:-latest} --dns-name-label ${PLUGIN_DNS} --ports ${PLUGIN_PORTS:-80} --registry-login-server ${PLUGIN_REGISTRY:-hub.docker.io} --registry-username ${PLUGIN_REGISTRY_USER} --registry-password ${PLUGIN_REGISTRY_PASSWORD} --environment-variables ${AZVARS//,/ }
+
+CREATE="az container create --resource-group ${PLUGIN_RESOURCE_GROUP} --name ${PLUGIN_CONTAINER_NAME} --image ${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION:-latest} --dns-name-label ${PLUGIN_DNS} --ports ${PLUGIN_PORTS:-80} --registry-login-server ${PLUGIN_REGISTRY:-hub.docker.io} --registry-username ${PLUGIN_REGISTRY_USER} --registry-password ${PLUGIN_REGISTRY_PASSWORD} --environment-variables ${AZVARS//,/ }"
+
+# Execute az container deploy command
+eval $CREATE

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 AZVARS="M5=Magna5"
 for var in ${PLUGIN_ENVVARS//,/ }; do
-  AZVARS=${AZVARS},$var="${!var:-missing}"
+  AZVARS="${AZVARS} $var=\"${!var:-missing}\""
 done
 
 # Put the env variables in quotes "" to accomodate space in values

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ set -x
 
 az login --service-principal -u ${PLUGIN_AZURE_APPID} -p ${PLUGIN_AZURE_PASSWORD} --tenant ${PLUGIN_AZURE_TENANT} || exit 1
 
-CREATE="az container create --resource-group ${PLUGIN_RESOURCE_GROUP} --name ${PLUGIN_CONTAINER_NAME} --image ${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION:-latest} --dns-name-label ${PLUGIN_DNS} --ports ${PLUGIN_PORTS:-80} --registry-login-server ${PLUGIN_REGISTRY:-hub.docker.io} --registry-username ${PLUGIN_REGISTRY_USER} --registry-password ${PLUGIN_REGISTRY_PASSWORD} --environment-variables ${AZVARS//,/ }"
+CREATE="az container create --resource-group ${PLUGIN_RESOURCE_GROUP} --name ${PLUGIN_CONTAINER_NAME} --image ${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION:-latest} --dns-name-label ${PLUGIN_DNS} --ports ${PLUGIN_PORTS:-80} --registry-login-server ${PLUGIN_REGISTRY:-hub.docker.io} --registry-username ${PLUGIN_REGISTRY_USER} --registry-password ${PLUGIN_REGISTRY_PASSWORD} --environment-variables ${AZVARS}"
 
 # Execute az container deploy command
 eval $CREATE

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,8 +5,6 @@ for var in ${PLUGIN_ENVVARS//,/ }; do
   AZVARS="${AZVARS} $var=\"${!var:-missing}\""
 done
 
-# Put the env variables in quotes "" to accomodate space in values
-AZVARS=$(echo $AZVARS | sed 's/=\([^,^$]*\)/="\1"/g')
 
 # Print the command being executed
 set -x


### PR DESCRIPTION
This commit will put the value of the args passed to the --environment-variables in double quotes so that if the value has space in them it is not considered as a seprate variable. The command for the azure container instance will happen using the eval command again for the reason of preserving the space in the --environment variables